### PR TITLE
Install typing module only for python<3.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     scripts=['scripts/pyrddl'],
     install_requires=[
         'ply',
-        'typing'
+        'typing; python_version<"3.5"'
     ],
     include_package_data=True,
     zip_safe=False,


### PR DESCRIPTION
This prevents shadowing the version of the module that comes with the stdlib since Python 3.5.
Quoting from the package pypi site (https://pypi.org/project/typing/):

"For package maintainers, it is preferred to use typing;python_version<"3.5" if your package requires it to support earlier Python versions. This will avoid shadowing the stdlib typing module when your package is installed via pip install -t . on Python 3.5 or later."

Incidentally, this fixes some bug caused by the two versions of typing coexisting that arises in some versions of Python 3.7, see e.g.:
https://github.com/pypa/pip/issues/8272
https://travis-ci.community/t/python-3-7-and-3-8-builds-are-failing-attributeerror-type-object-callable-has-no-attribute-abc-registry/10900